### PR TITLE
 Agregar seeds base de aportes para Global-Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,10 @@ git commit -m "Inicialización del nuevo proyecto"
 git branch -M main
 git push -u origin main
 ```
+
+## Ejecutar Seeder
+
+```bash
+cd "/home/dgbautista/Escritorio/Denzel AVANCE/Procedures Services Launcher/Procedures-Services-Launcher/Global-Service"
+pnpm run seed:run
+```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "seed:run": "yarn build && node ./node_modules/typeorm-extension/bin/cli.cjs seed:run -d src/database/data-source.ts",
+    "seed:run": "ts-node -r tsconfig-paths/register ./node_modules/typeorm-extension/bin/cli.cjs seed:run -d src/database/data-source.ts",
     "seed:create": "node ./node_modules/typeorm-extension/bin/cli.cjs seed:create",
     "migration:show": "ts-node -r tsconfig-paths/register ./node_modules/.bin/typeorm migration:show -d src/database/data-source.ts",
     "migration:create": "ts-node -r tsconfig-paths/register ./node_modules/.bin/typeorm migration:create src/database/migrations/",

--- a/src/config/envs.ts
+++ b/src/config/envs.ts
@@ -1,5 +1,8 @@
 import * as joi from 'joi';
 
+// Carga las variables de entorno desde el archivo .env
+process.loadEnvFile();
+
 interface EnvVars {
   NATS_SERVERS: string[];
   DB_PASSWORD: string;

--- a/src/database/seed-data/aportes.seed-data.ts
+++ b/src/database/seed-data/aportes.seed-data.ts
@@ -1,0 +1,296 @@
+export type SeedDocumentDefinition = {
+  name: string;
+  shortened: string;
+};
+
+export type SeedModalityDefinition = {
+  name: string;
+  shortened: string;
+};
+
+export type SeedProcedureTypeDefinition = {
+  name: string;
+  secondName: string;
+  modalities: SeedModalityDefinition[];
+};
+
+export const APORTES_MODULE_SEED = {
+  displayName: 'Contribuciones',
+  description: 'Contribuciones',
+  name: 'contribuciones',
+  shortened: 'CON',
+} as const;
+
+export const APORTES_PROCEDURE_TYPES: SeedProcedureTypeDefinition[] = [
+  {
+    name: 'Descuentos Anticipados',
+    secondName: 'Anticipado',
+    modalities: [
+      {
+        name: 'Servicio Pasivo Anticipo Titular',
+        shortened: 'SP-AT',
+      },
+      {
+        name: 'Servicio Pasivo Anticipo Viuda(o)',
+        shortened: 'SP-AV',
+      },
+    ],
+  },
+  {
+    name: 'Aportes Directos',
+    secondName: 'Directo',
+    modalities: [
+      {
+        name: 'Servicio Activo Comisión Ítem "0"',
+        shortened: 'SA-CI0',
+      },
+      {
+        name: 'Servicio Activo por Suspensión Temporal de Funciones',
+        shortened: 'SA-STF',
+      },
+      {
+        name:
+          'Servicio Activo con Destino a la Disponibilidad de la Letra "A" por Enfermedad',
+        shortened: 'SA-DDAE',
+      },
+      {
+        name: 'Reserva Activa Comisión Ítem "0"',
+        shortened: 'RA-CI0',
+      },
+      {
+        name: 'Reserva Activa por Suspensión Temporal de Funciones',
+        shortened: 'RA-STF',
+      },
+      {
+        name: 'Servicio Pasivo Titular',
+        shortened: 'SP-T',
+      },
+      {
+        name: 'Servicio Pasivo Viuda(o)',
+        shortened: 'SP-V',
+      },
+    ],
+  },
+  {
+    name: 'Regularización de Aportes',
+    secondName: 'Regularización',
+    modalities: [
+      {
+        name: 'Reincorporación de Servicio Activo Comisión Ítem "0"',
+        shortened: 'RSA-CI0',
+      },
+      {
+        name: 'Reincorporación de Servicio Activo por Suspensión Temporal de Funciones',
+        shortened: 'RSA-STF',
+      },
+      {
+        name:
+          'Reincorporación de Servicio Activo con Destino a la Disponibilidad de la Letra "A" por Enfermedad',
+        shortened: 'RSA-DDAE',
+      },
+      {
+        name: 'Reincorporación de Reserva Activa Comisión Ítem "0"',
+        shortened: 'RRA-CI0',
+      },
+      {
+        name: 'Reincorporación de Reserva Activa por Suspensión Temporal de Funciones',
+        shortened: 'RRA-STF',
+      },
+      {
+        name: 'Fallecimiento del Servicio Activo',
+        shortened: 'F-SA',
+      },
+      {
+        name: 'Fallecimiento de la Reserva Activa',
+        shortened: 'F-RA',
+      },
+      {
+        name: 'Fallecimiento del Servicio Pasivo Titular',
+        shortened: 'F-SPT',
+      },
+      {
+        name: 'Fallecimiento del Servicio Pasivo Viudo(a)',
+        shortened: 'F-SPV',
+      },
+    ],
+  },
+];
+
+export const APORTES_DOCUMENTS = {
+  memoComisionServicioItem0: {
+    name: 'Fotocopia del Memorándum de designación en Comisión de Servicio Ítem "0"',
+    shortened: 'FOT_MCSI0',
+  },
+  resolucionComisionServicioItem0: {
+    name: 'Fotocopia de la Resolución de designación en Comisión de Servicio Ítem "0"',
+    shortened: 'FOT_RCSI0',
+  },
+  memoSuspensionTemporalFunciones: {
+    name: 'Fotocopia del Memorándum de Suspensión Temporal de Funciones',
+    shortened: 'FOT_MSTF',
+  },
+  resolucionSuspensionTemporalFunciones: {
+    name: 'Fotocopia de la Resolución de Suspensión Temporal de Funciones',
+    shortened: 'FOT_RSTF',
+  },
+  memoDisponibilidadLetraAEnfermedad: {
+    name:
+      'Fotocopia del Memorándum de Destino a la Disponibilidad de la Letra "A" por Enfermedad',
+    shortened: 'FOT_MDLAE',
+  },
+  resolucionDisponibilidadLetraAEnfermedad: {
+    name:
+      'Fotocopia de la Resolución de Destino a la Disponibilidad de la Letra "A" por Enfermedad',
+    shortened: 'FOT_RDLAE',
+  },
+  memoDisponibilidadLetraCReservaActiva: {
+    name:
+      'Fotocopia del Memorándum de Destino a la Disponibilidad de la Letra "C" de la Reserva Activa',
+    shortened: 'FOT_MDLCRA',
+  },
+  resolucionDisponibilidadLetraCReservaActiva: {
+    name:
+      'Fotocopia de la Resolución de Destino a la Disponibilidad de la Letra "C" de la Reserva Activa',
+    shortened: 'FOT_RDLCRA',
+  },
+  memoDisponibilidadLetraAJubilacion: {
+    name:
+      'Fotocopia del Memorándum de Destino a la Disponibilidad de la Letra "A" por Jubilación',
+    shortened: 'FOT_MDLAJ',
+  },
+  resolucionDisponibilidadLetraAJubilacion: {
+    name:
+      'Fotocopia de la Resolución de Destino a la Disponibilidad de la Letra "A" por Jubilación',
+    shortened: 'FOT_RDLAJ',
+  },
+  memoReincorporacion: {
+    name: 'Fotocopia del Memorándum de Reincorporación',
+    shortened: 'FOT_MR',
+  },
+  resolucionReincorporacion: {
+    name: 'Fotocopia de la Resolución de Reincorporación',
+    shortened: 'FOT_RR',
+  },
+  certificadoComisionReincorporacion: {
+    name:
+      'Certificado de Trabajo original que detalle periodos de comisión y reincorporación',
+    shortened: 'CERT_CR',
+  },
+  certificadoSuspensionReincorporacion: {
+    name:
+      'Certificado de Trabajo original que detalle periodos de suspensión y reincorporación',
+    shortened: 'CERT_SR',
+  },
+  certificadoDestinoDisponibilidadReincorporacion: {
+    name:
+      'Certificado de Trabajo original que detalle periodos de destino a la disponibilidad y reincorporación',
+    shortened: 'CERT_DDR',
+  },
+  certificadoDefuncionTitular: {
+    name: 'Fotocopia del certificado de defunción de titular',
+    shortened: 'FOT_CDT',
+  },
+  certificadoDefuncionConyuge: {
+    name: 'Fotocopia del certificado de defunción de cónyuge',
+    shortened: 'FOT_CDC',
+  },
+  certificadoAniosServicio: {
+    name:
+      'Fotocopia del certificado de años de servicio del Comando General de la Policía Boliviana',
+    shortened: 'FOT_CAS',
+  },
+  contratoGestoraPublica: {
+    name: 'Fotocopia del Contrato de la Gestora Pública, AFP o Entidad Aseguradora',
+    shortened: 'FOT_CON',
+  },
+  memorandoAgradecimiento: {
+    name: 'Fotocopia de Memorándum de Agradecimiento',
+    shortened: 'FOT_MA',
+  },
+  certificadoDesvinculacion: {
+    name: 'Certificado de trabajo que detalle causal de desvinculación',
+    shortened: 'CERT_DESV',
+  },
+  certificadoMatrimonio: {
+    name: 'Fotocopia del certificado de matrimonio',
+    shortened: 'FOT_CM',
+  },
+  certificadoDefuncionViudo: {
+    name: 'Fotocopia del certificado de defunción de viudo (a)',
+    shortened: 'FOT_CDV',
+  },
+  compromisoAporteDirectoTitular: {
+    name: 'Compromiso de aporte directo titular',
+    shortened: 'CO_ADT',
+  },
+  compromisoAporteDirectoViuda: {
+    name: 'Compromiso de pago de aporte directo viuda',
+    shortened: 'CO_ADV',
+  },
+  compromisoCambioModalidadTitular: {
+    name: 'Compromiso Cambio de Modalidad Titular',
+    shortened: 'CO_CMT',
+  },
+  compromisoCambioModalidadViuda: {
+    name: 'Compromiso de Pago Cambio de Modalidad Viuda',
+    shortened: 'CO_CMV',
+  },
+  compromisoItem0ServicioActivo: {
+    name: 'Compromiso de Pago Item "0" - Servicio Activo',
+    shortened: 'CO_I0SA',
+  },
+  compromisoItem0ReservaActiva: {
+    name: 'Compromiso de Pago Ítem "0" - Reserva Activa',
+    shortened: 'CO_I0RA',
+  },
+  compromisoSuspendidoServicioActivo: {
+    name: 'Compromiso de Pago Suspendido - Servicio Activo',
+    shortened: 'CO_SSA',
+  },
+  compromisoSuspendidoReservaActiva: {
+    name: 'Compromiso de Pago Suspendido - Reserva Activa',
+    shortened: 'CO_SRA',
+  },
+  compromisoDisponibilidadEnfermedad: {
+    name: 'Compromiso de Pago Disponibilidad por Enfermedad',
+    shortened: 'CO_DE',
+  },
+  solicitudRegularizacionAmFallecimiento: {
+    name: 'Solicitud de Regularización de Aportes AM por Fallecimiento',
+    shortened: 'SOL_RAAMF',
+  },
+  solicitudRegularizacionCmFallecimiento: {
+    name: 'Solicitud de Regularización de Aportes CM por Fallecimiento',
+    shortened: 'SOL_RACMF',
+  },
+  solicitudRegularizacionReincorporacion: {
+    name: 'Solicitud de Regularización de Aportes (FRPS y/o CM) por reincorporación',
+    shortened: 'SOL_RAPR',
+  },
+} as const satisfies Record<string, SeedDocumentDefinition>;
+
+export type SeedRequirementDefinition = {
+  documentKey: keyof typeof APORTES_DOCUMENTS;
+  number: number;
+};
+
+export const APORTES_REQUIREMENT_PLACEHOLDERS = {
+  'SP-AT': [],
+  'SP-AV': [],
+  'SA-CI0': [],
+  'SA-STF': [],
+  'SA-DDAE': [],
+  'RA-CI0': [],
+  'RA-STF': [],
+  'SP-T': [],
+  'SP-V': [],
+  'RSA-CI0': [],
+  'RSA-STF': [],
+  'RSA-DDAE': [],
+  'RRA-CI0': [],
+  'RRA-STF': [],
+  'F-SA': [],
+  'F-RA': [],
+  'F-SPT': [],
+  'F-SPV': [],
+} as const satisfies Record<string, readonly SeedRequirementDefinition[]>;

--- a/src/database/seed-data/aportes.seed-utils.ts
+++ b/src/database/seed-data/aportes.seed-utils.ts
@@ -1,0 +1,32 @@
+export type NamedRecord = {
+  name: string;
+};
+
+export function normalizeText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+export function findByExactName<T extends NamedRecord>(
+  rows: T[],
+  name: string,
+): T | undefined {
+  const normalizedName = normalizeText(name);
+
+  return rows.find((row) => normalizeText(row.name) === normalizedName);
+}
+
+export function buildSeederError(
+  seederName: string,
+  error: unknown,
+): Error {
+  if (error instanceof Error) {
+    return new Error(`[${seederName}] ${error.message}`);
+  }
+
+  return new Error(`[${seederName}] Unexpected error: ${String(error)}`);
+}

--- a/src/database/seeds/001-aportes-modules.seed.ts
+++ b/src/database/seeds/001-aportes-modules.seed.ts
@@ -1,0 +1,44 @@
+import { DataSource } from 'typeorm';
+import { Seeder, SeederFactoryManager } from 'typeorm-extension';
+import { Module } from 'src/modules/entities';
+import { APORTES_MODULE_SEED } from 'src/database/seed-data/aportes.seed-data';
+import { buildSeederError } from 'src/database/seed-data/aportes.seed-utils';
+
+export default class AportesModulesSeed implements Seeder {
+  track = false;
+
+  public async run(
+    dataSource: DataSource,
+    _factoryManager: SeederFactoryManager,
+  ): Promise<void> {
+    const seederName = AportesModulesSeed.name;
+
+    try {
+      const repository = dataSource.getRepository(Module);
+
+      const moduleByName = await repository.findOne({
+        where: { name: APORTES_MODULE_SEED.name },
+      });
+
+      if (moduleByName) {
+        return;
+      }
+
+      const moduleByTuple = await repository.findOne({
+        where: {
+          displayName: APORTES_MODULE_SEED.displayName,
+          description: APORTES_MODULE_SEED.description,
+          shortened: APORTES_MODULE_SEED.shortened,
+        },
+      });
+
+      if (moduleByTuple) {
+        return;
+      }
+
+      await repository.save(repository.create(APORTES_MODULE_SEED));
+    } catch (error) {
+      throw buildSeederError(seederName, error);
+    }
+  }
+}

--- a/src/database/seeds/002-aportes-procedure-types.seed.ts
+++ b/src/database/seeds/002-aportes-procedure-types.seed.ts
@@ -1,0 +1,64 @@
+import { DataSource } from 'typeorm';
+import { Seeder, SeederFactoryManager } from 'typeorm-extension';
+import { Module, ProcedureType } from 'src/modules/entities';
+import {
+  APORTES_MODULE_SEED,
+  APORTES_PROCEDURE_TYPES,
+} from 'src/database/seed-data/aportes.seed-data';
+import {
+  buildSeederError,
+  findByExactName,
+} from 'src/database/seed-data/aportes.seed-utils';
+
+export default class AportesProcedureTypesSeed implements Seeder {
+  track = false;
+
+  public async run(
+    dataSource: DataSource,
+    _factoryManager: SeederFactoryManager,
+  ): Promise<void> {
+    const seederName = AportesProcedureTypesSeed.name;
+
+    try {
+      const moduleRepository = dataSource.getRepository(Module);
+      const procedureTypeRepository = dataSource.getRepository(ProcedureType);
+
+      const moduleEntity = await moduleRepository.findOne({
+        where: { name: APORTES_MODULE_SEED.name },
+      });
+
+      if (!moduleEntity) {
+        throw new Error(
+          'No se encontró el módulo "contribuciones" para sembrar procedure_types.',
+        );
+      }
+
+      const existingProcedureTypes = await procedureTypeRepository.find({
+        relations: ['module'],
+        where: { module: { id: moduleEntity.id } },
+        withDeleted: true,
+      });
+
+      for (const procedureTypeSeed of APORTES_PROCEDURE_TYPES) {
+        const existingProcedureType = findByExactName(
+          existingProcedureTypes,
+          procedureTypeSeed.name,
+        );
+
+        if (existingProcedureType) {
+          continue;
+        }
+
+        const createdProcedureType = procedureTypeRepository.create({
+          module: moduleEntity,
+          name: procedureTypeSeed.name,
+          secondName: procedureTypeSeed.secondName,
+        });
+
+        await procedureTypeRepository.save(createdProcedureType);
+      }
+    } catch (error) {
+      throw buildSeederError(seederName, error);
+    }
+  }
+}

--- a/src/database/seeds/003-aportes-procedure-modalities.seed.ts
+++ b/src/database/seeds/003-aportes-procedure-modalities.seed.ts
@@ -1,0 +1,103 @@
+import { DataSource, In, Repository } from 'typeorm';
+import { Seeder, SeederFactoryManager } from 'typeorm-extension';
+import { ProcedureModality, ProcedureType } from 'src/modules/entities';
+import {
+  APORTES_PROCEDURE_TYPES,
+  SeedProcedureTypeDefinition,
+} from 'src/database/seed-data/aportes.seed-data';
+import {
+  buildSeederError,
+  findByExactName,
+} from 'src/database/seed-data/aportes.seed-utils';
+
+export default class AportesProcedureModalitiesSeed implements Seeder {
+  track = false;
+
+  public async run(
+    dataSource: DataSource,
+    _factoryManager: SeederFactoryManager,
+  ): Promise<void> {
+    const seederName = AportesProcedureModalitiesSeed.name;
+
+    try {
+      const procedureTypeRepository = dataSource.getRepository(ProcedureType);
+      const procedureModalityRepository =
+        dataSource.getRepository(ProcedureModality);
+
+      const procedureTypeNames = APORTES_PROCEDURE_TYPES.map(
+        (procedureType) => procedureType.name,
+      );
+
+      const procedureTypes = await procedureTypeRepository.find({
+        where: procedureTypeNames.map((name) => ({ name })),
+        withDeleted: true,
+      });
+
+      const procedureTypeIds = procedureTypes.map((procedureType) => procedureType.id);
+      const existingProcedureModalities =
+        procedureTypeIds.length > 0
+          ? await procedureModalityRepository.find({
+              relations: ['procedureType'],
+              where: {
+                procedureType: {
+                  id: In(procedureTypeIds),
+                },
+              },
+            })
+          : [];
+
+      for (const procedureTypeSeed of APORTES_PROCEDURE_TYPES) {
+        const procedureType = findByExactName(
+          procedureTypes,
+          procedureTypeSeed.name,
+        );
+
+        if (!procedureType) {
+          throw new Error(
+            `No se encontró procedure_type para "${procedureTypeSeed.name}".`,
+          );
+        }
+
+        await this.seedModalitiesForType(
+          procedureModalityRepository,
+          existingProcedureModalities,
+          procedureType,
+          procedureTypeSeed,
+        );
+      }
+    } catch (error) {
+      throw buildSeederError(seederName, error);
+    }
+  }
+
+  private async seedModalitiesForType(
+    procedureModalityRepository: Repository<ProcedureModality>,
+    existingProcedureModalities: ProcedureModality[],
+    procedureType: ProcedureType,
+    procedureTypeSeed: SeedProcedureTypeDefinition,
+  ): Promise<void> {
+    for (const modalitySeed of procedureTypeSeed.modalities) {
+      const existingProcedureModality = existingProcedureModalities.find(
+        (procedureModality) =>
+          procedureModality.procedureType?.id === procedureType.id &&
+          findByExactName([procedureModality], modalitySeed.name),
+      );
+
+      if (existingProcedureModality) {
+        continue;
+      }
+
+      const createdProcedureModality = procedureModalityRepository.create({
+        isValid: true,
+        name: modalitySeed.name,
+        procedureType,
+        shortened: modalitySeed.shortened,
+      });
+
+      const savedProcedureModality =
+        await procedureModalityRepository.save(createdProcedureModality);
+
+      existingProcedureModalities.push(savedProcedureModality);
+    }
+  }
+}

--- a/src/database/seeds/004-aportes-procedure-documents.seed.ts
+++ b/src/database/seeds/004-aportes-procedure-documents.seed.ts
@@ -1,0 +1,63 @@
+import { DataSource } from 'typeorm';
+import { Seeder, SeederFactoryManager } from 'typeorm-extension';
+import { ProcedureDocument } from 'src/procedure-documents/entities/procedure-document.entity';
+import {
+  APORTES_DOCUMENTS,
+  SeedDocumentDefinition,
+} from 'src/database/seed-data/aportes.seed-data';
+import {
+  buildSeederError,
+  findByExactName,
+} from 'src/database/seed-data/aportes.seed-utils';
+
+export default class AportesProcedureDocumentsSeed implements Seeder {
+  track = false;
+
+  public async run(
+    dataSource: DataSource,
+    _factoryManager: SeederFactoryManager,
+  ): Promise<void> {
+    const seederName = AportesProcedureDocumentsSeed.name;
+
+    try {
+      const repository = dataSource.getRepository(ProcedureDocument);
+      const existingDocuments = await repository.find();
+
+      for (const documentSeed of Object.values(
+        APORTES_DOCUMENTS,
+      ) as SeedDocumentDefinition[]) {
+        const existingDocument = findByExactName(
+          existingDocuments,
+          documentSeed.name,
+        );
+
+        if (existingDocument) {
+          continue;
+        }
+
+        const existingByShortened = existingDocuments.find(
+          (document) => document.shortened === documentSeed.shortened,
+        );
+
+        if (existingByShortened) {
+          throw new Error(
+            `Ya existe un procedure_document con shortened "${documentSeed.shortened}" y nombre "${existingByShortened.name}".`,
+          );
+        }
+
+        const createdDocument = repository.create({
+          createdAt: new Date(),
+          expireDate: null,
+          name: documentSeed.name,
+          shortened: documentSeed.shortened,
+          updatedAt: new Date(),
+        });
+
+        const savedDocument = await repository.save(createdDocument);
+        existingDocuments.push(savedDocument);
+      }
+    } catch (error) {
+      throw buildSeederError(seederName, error);
+    }
+  }
+}

--- a/src/database/seeds/005-aportes-procedure-requirements.seed.ts
+++ b/src/database/seeds/005-aportes-procedure-requirements.seed.ts
@@ -1,0 +1,26 @@
+import { DataSource } from 'typeorm';
+import { Seeder, SeederFactoryManager } from 'typeorm-extension';
+import { APORTES_REQUIREMENT_PLACEHOLDERS } from 'src/database/seed-data/aportes.seed-data';
+import { buildSeederError } from 'src/database/seed-data/aportes.seed-utils';
+
+export default class AportesProcedureRequirementsSeed implements Seeder {
+  track = false;
+
+  public async run(
+    _dataSource: DataSource,
+    _factoryManager: SeederFactoryManager,
+  ): Promise<void> {
+    const seederName = AportesProcedureRequirementsSeed.name;
+
+    try {
+      // Placeholder: las relaciones de procedure_requirements se completarán
+      // en la siguiente edición. Por ahora no se inserta ninguna fila.
+      // Se deja esta estructura pendiente para evitar que se pierda el trabajo
+      // realizado por mi dgbautista.
+      const pendingRequirementStructure = APORTES_REQUIREMENT_PLACEHOLDERS;
+      void pendingRequirementStructure;
+    } catch (error) {
+      throw buildSeederError(seederName, error);
+    }
+  }
+}


### PR DESCRIPTION
## Resumen

Se incorporó el seed base del bloque de Aportes en `public` para las tablas:

- `modules`
- `procedure_types`
- `procedure_modalities`
- `procedure_documents`
- `procedure_requirements` (solo estructura placeholder por ahora)

Además, se ajustó la forma de ejecutar el seeder con `pnpm` y se documentó su uso en el README.

## Cambios realizados

- Se agregó la data canon del módulo `contribuciones` con validación para no crear duplicados.
- Se agregaron los 3 `procedure_types` de Aportes:
  - `Descuentos Anticipados`
  - `Aportes Directos`
  - `Regularización de Aportes`
- Se agregaron las 18 `procedure_modalities` asociadas dinámicamente a sus tipos reales en BD.
- Se agregaron los 35 `procedure_documents` con sus siglas oficiales (`shortened`).
- Se dejó `procedure_requirements` sin inserciones en esta iteración, pero con estructura lista para una siguiente edición.
- Se simplificó la lógica de seeds para que trabaje con coincidencia exacta por nombre, sin alias ni matching difuso.
- Se agregó manejo de errores contextualizado por seeder (`try/catch`).
- Se dejó el comando de ejecución del seeder funcionando con `pnpm`.
- Se agregó al README un ejemplo corto de ejecución en consola.

## Comportamiento esperado

- El seed crea solo registros faltantes.
- Si una fila ya existe, no la modifica ni la duplica.
- Las relaciones se resuelven usando IDs dinámicos obtenidos desde la BD.
- No se depende de IDs fijos para `modules`, `procedure_types` o `procedure_modalities`.

## Validación realizada

Se validó con:

- `pnpm build`
- `pnpm run seed:run`
- segunda ejecución de `pnpm run seed:run` para comprobar idempotencia

Resultado verificado:

- `modules`: 1 registro objetivo
- `procedure_types`: 3 registros
- `procedure_modalities`: 18 registros
- `procedure_documents`: 35 registros
- `procedure_requirements`: 0 registros en esta iteración

## Nota

`procedure_requirements` queda intencionalmente pendiente para una próxima edición, donde se cargarán las relaciones finales por modalidad.
