### PR TITLE
Dev - Se agregó el método accountsAllData a AccountController y se actualizó AccountService para la recuperación detallada de cuentas.

### DIFF
--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -10,4 +10,10 @@ export class AccountController {
   async accounts() {
     return this.accountService.accounts();
   }
+
+  // mostrar todas las cuentas con todos sus datos, incluyendo el contenido financialEntityId
+  @MessagePattern('global.accountsAllData')
+  async accountsAllData() {
+    return this.accountService.accountsAllData();
+  }
 }

--- a/src/account/account.module.ts
+++ b/src/account/account.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AccountService } from './account.service';
 import { AccountController } from './account.controller';
 import { Account } from './entities/account.entity';
+import { FinancialEntity } from '../financial-entities/entities/financial-entity.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Account])],
+  imports: [TypeOrmModule.forFeature([Account, FinancialEntity])],
   controllers: [AccountController],
   providers: [AccountService],
 })

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { In, Repository } from 'typeorm';
 import { Account } from './entities/account.entity';
 import { InjectRepository } from '@nestjs/typeorm/dist/common/typeorm.decorators';
+import { FinancialEntity } from '../financial-entities/entities/financial-entity.entity';
 
 @Injectable()
 export class AccountService {
@@ -10,6 +11,8 @@ export class AccountService {
   constructor(
     @InjectRepository(Account)
     private readonly accountRepository: Repository<Account>,
+    @InjectRepository(FinancialEntity)
+    private readonly financialEntityRepository: Repository<FinancialEntity>,
   ) {}
 
   async accounts(): Promise<{
@@ -56,4 +59,82 @@ export class AccountService {
     }
   }
 
+  async accountsAllData(): Promise<{
+    error: boolean;
+    message: string;
+    data:
+      | {
+          id: number;
+          name: string;
+          state: string;
+          accountNumber: string;
+          ciNitTitular: string;
+          cta: string;
+          financialEntity: Pick<
+            FinancialEntity,
+            'id' | 'name' | 'code' | 'isActive' | 'eif'
+          > | null;
+        }[]
+      | null;
+  }> {
+    try {
+      const accounts = await this.accountRepository.find({
+        select: [
+          'id',
+          'financialEntityId',
+          'name',
+          'state',
+          'accountNumber',
+          'ciNitTitular',
+          'cta',
+        ],
+      });
+      const financialEntityIds = [
+        ...new Set(accounts.map((account) => account.financialEntityId)),
+      ];
+
+      const financialEntities = financialEntityIds.length
+        ? await this.financialEntityRepository.find({
+            select: ['id', 'name', 'code', 'isActive', 'eif'],
+            where: { id: In(financialEntityIds) },
+          })
+        : [];
+
+      const financialEntitiesById = new Map(
+        financialEntities.map((financialEntity) => [
+          financialEntity.id,
+          financialEntity,
+        ]),
+      );
+
+      return {
+        error: false,
+        message: 'Cuentas obtenidas correctamente',
+        data: accounts.map((account) => {
+          const financialEntity =
+            financialEntitiesById.get(account.financialEntityId) ?? null;
+
+          return {
+            id: account.id,
+            name: account.name,
+            state: account.state,
+            accountNumber: account.accountNumber,
+            ciNitTitular: account.ciNitTitular,
+            cta: account.cta,
+            financialEntity,
+          };
+        }),
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error al obtener todas las cuentas: ${error.message}`,
+        error.stack,
+      );
+      return {
+        error: true,
+        message: 'Error al obtener todas las cuentas',
+        data: null,
+      };
+    }
+  }
 }

--- a/src/config/envs.ts
+++ b/src/config/envs.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config';
+// import 'dotenv/config';
 import * as joi from 'joi';
 
 interface EnvVars {

--- a/src/database/migrations/1779696000000-addTableAccountsAndPaymentLocations.ts
+++ b/src/database/migrations/1779696000000-addTableAccountsAndPaymentLocations.ts
@@ -160,6 +160,23 @@ export class AddTableAccountsAndFinancialEntities1779696000000 implements Migrat
         ],
       }),
     );
+
+    await queryRunner.query(`
+      INSERT INTO ${getSchema(queryRunner)}.accounts
+        (id, financial_entity_id, name, state, account_number, cta, ci_nit_titular)
+      VALUES
+        (1, 14, 'SERVICIOS VARIOS', 'activo', '133175642', '0', '234578021'),
+        (2, 14, 'AUXILIO MORTUORIO', 'activo', '133175741', '0', '234578021'),
+        (3, 14, 'PRÉSTAMOS Y DIVIDENDOS', 'activo', '133175676', '0', '234578021'),
+        (4, 14, 'FONDO DE RETIRO Y CUOTA MORTUORIA', 'activo', '133175733', '0', '234578021')
+    `);
+
+    await queryRunner.query(`
+      SELECT setval(
+        pg_get_serial_sequence('${getSchema(queryRunner)}.accounts', 'id'),
+        (SELECT MAX(id) FROM ${getSchema(queryRunner)}.accounts)
+      )
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/database/seeds/accounts.seeder.ts
+++ b/src/database/seeds/accounts.seeder.ts
@@ -1,20 +1,15 @@
 import { ClientProxy, ClientProxyFactory, Transport } from '@nestjs/microservices';
-import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
+import { DataSource, In } from 'typeorm';
 import { Seeder } from 'typeorm-extension';
 import { firstValueFrom, timeout } from 'rxjs';
 import { Account } from '../../account/entities/account.entity';
 import { FinancialEntity } from '../../financial-entities/entities/financial-entity.entity';
 import { NastEnvs } from '../../config';
 
-type SeedAccount = {
-  id: number;
-  financialEntityId: number;
-  name: string;
-  state: string;
-  accountNumber: string;
-  cta: string;
-  ciNitTitular: string;
-};
+type BcbSyncAccount = Pick<
+  Account,
+  'id' | 'financialEntityId' | 'name' | 'state' | 'accountNumber' | 'ciNitTitular'
+>;
 
 type BcbAccount = {
   eif?: string;
@@ -25,56 +20,30 @@ type BcbAccount = {
   estado?: string;
 };
 
-const ACCOUNTS: SeedAccount[] = [
-  {
-    id: 1,
-    financialEntityId: 14,
-    name: 'SERVICIOS VARIOS',
-    state: 'activo',
-    accountNumber: '1-33175642',
-    cta: '0',
-    ciNitTitular: '234578021',
-  },
-  {
-    id: 2,
-    financialEntityId: 14,
-    name: 'AUXILIO MORTUORIO',
-    state: 'activo',
-    accountNumber: '1-33175741',
-    cta: '0',
-    ciNitTitular: '234578021',
-  },
-  {
-    id: 3,
-    financialEntityId: 14,
-    name: 'PRÉSTAMOS Y DIVIDENDOS',
-    state: 'activo',
-    accountNumber: '1-33175676',
-    cta: '0',
-    ciNitTitular: '234578021',
-  },
-  {
-    id: 4,
-    financialEntityId: 14,
-    name: 'FONDO DE RETIRO Y CUOTA MORTUORIA',
-    state: 'activo',
-    accountNumber: '1-33175733',
-    cta: '0',
-    ciNitTitular: '234578021',
-  },
-];
-
 export default class AccountsSeeder implements Seeder {
   track = true;
 
   async run(dataSource: DataSource): Promise<void> {
     const accountRepository = dataSource.getRepository(Account);
+    const accounts = await accountRepository.find({
+      select: [
+        'id',
+        'financialEntityId',
+        'name',
+        'state',
+        'accountNumber',
+        'ciNitTitular',
+      ],
+    });
 
-    for (const account of ACCOUNTS) {
-      await this.upsertLocalAccount(accountRepository, account);
+    if (accounts.length === 0) {
+      return;
     }
 
-    const financialEntityEifs = await this.getFinancialEntityEifs(dataSource);
+    const financialEntityEifs = await this.getFinancialEntityEifs(
+      dataSource,
+      accounts,
+    );
     const client = ClientProxyFactory.create({
       transport: Transport.NATS,
       options: {
@@ -87,7 +56,7 @@ export default class AccountsSeeder implements Seeder {
     try {
       let bcbAccounts = await this.getBcbAccounts(client);
 
-      for (const account of ACCOUNTS) {
+      for (const account of accounts) {
         const financialEntityEif = financialEntityEifs.get(account.financialEntityId);
 
         if (!financialEntityEif) {
@@ -116,28 +85,24 @@ export default class AccountsSeeder implements Seeder {
           throw new Error(`BCB no devolvio cta para la cuenta ${account.name}`);
         }
 
-        await this.upsertLocalAccount(accountRepository, {
-          ...account,
-          cta: bcbAccount.cta,
-        });
+        await accountRepository.update({ id: account.id }, { cta: bcbAccount.cta });
       }
     } finally {
       await client.close();
     }
-
-    await this.syncAccountSequence(dataSource);
   }
 
   private async getFinancialEntityEifs(
     dataSource: DataSource,
+    accounts: BcbSyncAccount[],
   ): Promise<Map<number, string>> {
     const financialEntityIds = [
-      ...new Set(ACCOUNTS.map((account) => account.financialEntityId)),
+      ...new Set(accounts.map((account) => account.financialEntityId)),
     ];
     const financialEntityRepository = dataSource.getRepository(FinancialEntity);
     const financialEntities = await financialEntityRepository.find({
       select: ['id', 'eif'],
-      where: financialEntityIds.map((id) => ({ id })),
+      where: { id: In(financialEntityIds) },
     });
 
     return new Map(
@@ -169,7 +134,7 @@ export default class AccountsSeeder implements Seeder {
   private async createBcbAccount(
     client: ClientProxy,
     financialEntityEif: string,
-    account: SeedAccount,
+    account: BcbSyncAccount,
   ): Promise<void> {
     const response = await this.sendBcbMessage(client, 'bcb.createAccount', {
       eif: financialEntityEif,
@@ -193,7 +158,7 @@ export default class AccountsSeeder implements Seeder {
   private findBcbAccount(
     accounts: BcbAccount[],
     financialEntityEif: string,
-    account: SeedAccount,
+    account: BcbSyncAccount,
   ): BcbAccount | undefined {
     return accounts.find(
       (bcbAccount) =>
@@ -202,41 +167,7 @@ export default class AccountsSeeder implements Seeder {
     );
   }
 
-  private async upsertLocalAccount(
-    accountRepository: Repository<Account>,
-    account: SeedAccount,
-  ): Promise<void> {
-    const where: FindOptionsWhere<Account>[] = [
-      { id: account.id },
-      { accountNumber: account.accountNumber },
-    ];
-
-    const existingAccount = await accountRepository.findOne({ where });
-
-    await accountRepository.save({
-      ...(existingAccount ?? {}),
-      id: existingAccount?.id ?? account.id,
-      financialEntityId: account.financialEntityId,
-      name: account.name,
-      state: account.state,
-      accountNumber: account.accountNumber,
-      cta: account.cta,
-      ciNitTitular: account.ciNitTitular,
-    });
-  }
-
   private toBcbAccountNumber(accountNumber: string): string {
     return accountNumber.replace(/\D/g, '');
-  }
-
-  private async syncAccountSequence(dataSource: DataSource): Promise<void> {
-    const schema = (dataSource.options as { schema?: string }).schema ?? 'global';
-
-    await dataSource.query(`
-      SELECT setval(
-        pg_get_serial_sequence('${schema}.accounts', 'id'),
-        COALESCE((SELECT MAX(id) FROM ${schema}.accounts), 1)
-      )
-    `);
   }
 }


### PR DESCRIPTION
Se agregó el método accountsAllData a AccountController y se actualizó AccountService para la recuperación detallada de cuentas.

- Se implementó el método accountsAllData en AccountController para obtener cuentas con detalles de entidades financieras.

- Se mejoró AccountService para incluir la lógica de accountsAllData y así obtener datos completos de las cuentas.

- Se actualizó AccountModule para incluir el repositorio FinancialEntity.

- AccountsSeeder ahora queda pensado solo para sincronizar con BCB:
-- Lee las cuentas existentes desde la tabla accounts.
-- Obtiene el eif desde financial_entities.
-- Consulta si esas cuentas existen en BCB.
-- Si no existen, las crea en BCB.
-- Recupera el cta.
-- Actualiza únicamente el campo cta en nuestra tabla accounts.

- Se comentó la importación de dotenv en envs.ts para posibles ajustes de configuración.